### PR TITLE
test/add functional tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,6 +3,8 @@ ThisBuild / organization := "io.github.rustfields"
 ThisBuild / scalaVersion := "3.3.0"
 ThisBuild / scalacOptions ++= Seq("-feature", "-deprecation")
 
+fork := true
+
 lazy val root = project
   .in(file("."))
   .settings(

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,7 @@
 ThisBuild / version := "5.0.0"
 ThisBuild / organization := "io.github.rustfields"
 ThisBuild / scalaVersion := "3.3.0"
+ThisBuild / scalacOptions ++= Seq("-feature", "-deprecation")
 
 lazy val root = project
   .in(file("."))

--- a/src/test/scala/io/github/rustfields/ContextTest.scala
+++ b/src/test/scala/io/github/rustfields/ContextTest.scala
@@ -4,6 +4,7 @@ import io.github.rustfields.vm.Sensor.given
 import io.github.rustfields.vm.Slot.{Nbr, Rep}
 import io.github.rustfields.vm.{Context, Export, Sensor}
 import org.scalatest.flatspec.AnyFlatSpec
+import scala.language.implicitConversions
 
 class ContextTest extends AnyFlatSpec:
 

--- a/src/test/scala/io/github/rustfields/functional/CoreTestInterpreter.scala
+++ b/src/test/scala/io/github/rustfields/functional/CoreTestInterpreter.scala
@@ -1,0 +1,5 @@
+package io.github.rustfields.functional
+
+import io.github.rustfields.lang.FieldCalculusInterpreter
+
+object CoreTestInterpreter extends FieldCalculusInterpreter

--- a/src/test/scala/io/github/rustfields/functional/CoreTestUtils.scala
+++ b/src/test/scala/io/github/rustfields/functional/CoreTestUtils.scala
@@ -1,0 +1,40 @@
+package io.github.rustfields.functional
+
+import io.github.rustfields.lang.FieldCalculusInterpreter
+import io.github.rustfields.vm.{Context, Export, Sensor}
+
+import scala.collection.mutable
+
+trait CoreTestUtils:
+  def ctx(
+           selfId: Int,
+           exports: Map[Int, Export] = Map(),
+           lsens: Map[String, Any] = Map(),
+           nbsens: Map[String, Map[Int, Any]] = Map(),
+         ): Context =
+    val localSensorsWithId = lsens.map((k, v) => Sensor(k) -> v)
+    val neighborhoodSensorWithId = nbsens.map((k, v) => Sensor(k) -> v)
+    Context(selfId, exports, localSensorsWithId, neighborhoodSensorWithId)
+
+  def assertEquivalence[T](
+                            nbrs: Map[Int, List[Int]], 
+                            execOrder: Iterable[Int], 
+                            comparer: (T, T) => Boolean = (_: Any) == (_: Any),
+                          )(program1: => Any)(program2: => Any)(using interpreter: FieldCalculusInterpreter): Boolean =
+    val states = mutable.Map[Int, (Export, Export)]()
+    execOrder.foreach { curr =>
+      val nbrExports = states.view.filterKeys(nbrs(curr).contains(_))
+      val currCtx1 = ctx(curr, exports = nbrExports.mapValues(_._1).toMap)
+      val currCtx2 = ctx(curr, exports = nbrExports.mapValues(_._2).toMap)
+      val exp1 = interpreter.round(currCtx1, program1)
+      val exp2 = interpreter.round(currCtx2, program2)
+      if (!comparer(exp1.root(), exp2.root()))
+        throw new Exception(s"Not equivalent: \n$exp1\n$currCtx1\n--------\n$exp2\n$currCtx2")
+      states.put(curr, (exp1, exp2))
+    }
+    true
+
+  def fullyConnectedTopologyMap(elems: Iterable[Int]): Map[Int, List[Int]] =
+    elems.map(elem => elem -> elems.toList).toMap
+
+object CoreTestUtils extends CoreTestUtils

--- a/src/test/scala/io/github/rustfields/functional/TestByEquivalence.scala
+++ b/src/test/scala/io/github/rustfields/functional/TestByEquivalence.scala
@@ -12,7 +12,7 @@ class TestByEquivalence extends AnyFlatSpec:
   import CoreTestInterpreter.*
   class Fixture:
     val random = new Random(0)
-    val execSequence: LazyList[Int] = LazyList.continually(Random.nextInt(3)).take(100)
+    val execSequence: LazyList[Int] = LazyList.continually(random.nextInt(3)).take(100)
     val devicesAndNbrs: Map[Int, List[Int]] = fullyConnectedTopologyMap(List(0, 1, 2))
 
   "fold" should "work with multiple nbrs" in {
@@ -61,7 +61,8 @@ class TestByEquivalence extends AnyFlatSpec:
   }
 
   "Performance" should "not degrade when nesting foldhoods" in {
-    val execSequence = LazyList.continually(Random.nextInt(100)).take(1000)
+    val random = new Random(0)
+    val execSequence = LazyList.continually(random.nextInt(100)).take(1000)
     val devicesAndNbrs = fullyConnectedTopologyMap(0 to 99)
     // fold.fold : performance
     // NOTE: pay attention to double overflow

--- a/src/test/scala/io/github/rustfields/functional/TestByEquivalence.scala
+++ b/src/test/scala/io/github/rustfields/functional/TestByEquivalence.scala
@@ -1,5 +1,95 @@
 package io.github.rustfields.functional
 
-class TestByEquivalence {
+import CoreTestInterpreter.nbr
+import CoreTestUtils.{assertEquivalence, fullyConnectedTopologyMap}
+import io.github.rustfields.lang.FieldCalculusInterpreter
+import org.scalatest.flatspec.AnyFlatSpec
+import scala.util.Random
 
-}
+class TestByEquivalence extends AnyFlatSpec:
+
+  given FieldCalculusInterpreter = CoreTestInterpreter
+  import CoreTestInterpreter.*
+  class Fixture:
+    val random = new Random(0)
+    val execSequence: LazyList[Int] = LazyList.continually(Random.nextInt(3)).take(100)
+    val devicesAndNbrs: Map[Int, List[Int]] = fullyConnectedTopologyMap(List(0, 1, 2))
+
+  "foldhood" should "work with multiple nbrs" in {
+    val fixture = new Fixture
+    assertEquivalence(fixture.devicesAndNbrs, fixture.execSequence) {
+      foldhood(0)(_ + _)(nbr(1) + nbr(2) + nbr(mid()))
+    } {
+      foldhood(0)(_ + _)(nbr(1 + 2 + mid()))
+    }
+  }
+
+  "rep.nbr" should "be ignored on first argument" in {
+    val fixture = new Fixture
+    assertEquivalence(fixture.devicesAndNbrs, fixture.execSequence) {
+      foldhood(0)(_ + _)(rep(nbr(mid()))(old => old))
+    } {
+      foldhood(0)(_ + _)(rep(mid())(old => old))
+    }
+  }
+
+  "rep.nbr" should "be ignored overall" in {
+    val fixture = new Fixture
+    assertEquivalence(fixture.devicesAndNbrs, fixture.execSequence){
+      foldhood(0)(_ + _)(rep(nbr(mid()))(old => old + nbr(old) + nbr(mid())))
+    } {
+      foldhood(0)(_ + _)(1) * rep(mid())(old => old * 2 + mid())
+    }
+  }
+
+  "fold.init nbr" should "be ignored" in {
+    val fixture = new Fixture
+    assertEquivalence(fixture.devicesAndNbrs, fixture.execSequence) {
+      foldhood(0)(_ + _)(foldhood(nbr(mid()))(_ + _)(1))
+    } {
+      foldhood(0)(_ + _)(1) * foldhood(mid())(_ + _)(1)
+    }
+  }
+
+  "fold.fold" should "work" in {
+    val fixture = new Fixture
+    assertEquivalence(fixture.devicesAndNbrs, fixture.execSequence) {
+      foldhood(0)(_ + _)(foldhood(0)(_ + _)(1))
+    } {
+      Math.pow(foldhood(0)(_ + _)(1), 2)
+    }
+  }
+
+  "Performance" should "not degrade when nesting foldhoods" in {
+    val execSequence = LazyList.continually(Random.nextInt(100)).take(1000)
+    val devicesAndNbrs = fullyConnectedTopologyMap(0 to 99)
+    // fold.fold : performance
+    // NOTE: pay attention to double overflow
+    assertEquivalence(
+      devicesAndNbrs,
+      execSequence,
+      (x: Double, y: Double) => Math.abs(x - y) / Math.max(Math.abs(x), Math.abs(y)) < 0.000001
+    ) {
+      foldhood(0.0)(_ + _) {
+        foldhood(0.0)(_ + _) {
+          foldhood(0.0)(_ + _) {
+            foldhood(0.0)(_ + _) {
+              foldhood(0.0)(_ + _) {
+                foldhood(0.0)(_ + _) {
+                  foldhood(0.0)(_ + _) {
+                    foldhood(0.0)(_ + _) {
+                      foldhood(0.0)(_ + _) {
+                        foldhood(0.0)(_ + _)(1.0)
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    } {
+      Math.pow(foldhood(0.0)(_ + _)(1.0), 10)
+    }
+  }

--- a/src/test/scala/io/github/rustfields/functional/TestByEquivalence.scala
+++ b/src/test/scala/io/github/rustfields/functional/TestByEquivalence.scala
@@ -15,7 +15,7 @@ class TestByEquivalence extends AnyFlatSpec:
     val execSequence: LazyList[Int] = LazyList.continually(Random.nextInt(3)).take(100)
     val devicesAndNbrs: Map[Int, List[Int]] = fullyConnectedTopologyMap(List(0, 1, 2))
 
-  "foldhood" should "work with multiple nbrs" in {
+  "fold" should "work with multiple nbrs" in {
     val fixture = new Fixture
     assertEquivalence(fixture.devicesAndNbrs, fixture.execSequence) {
       foldhood(0)(_ + _)(nbr(1) + nbr(2) + nbr(mid()))

--- a/src/test/scala/io/github/rustfields/functional/TestByEquivalence.scala
+++ b/src/test/scala/io/github/rustfields/functional/TestByEquivalence.scala
@@ -1,0 +1,5 @@
+package io.github.rustfields.functional
+
+class TestByEquivalence {
+
+}

--- a/src/test/scala/io/github/rustfields/functional/TestSemanticsByRound.scala
+++ b/src/test/scala/io/github/rustfields/functional/TestSemanticsByRound.scala
@@ -8,6 +8,7 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.matchers.should.Matchers.shouldBe
 import io.github.rustfields.vm.Path.*
+import scala.language.implicitConversions
 
 class TestSemanticsByRound extends AnyFunSpec with Matchers:
   val LocalValues, Alignment, Exports, FOLDHOOD, NBR, REP, BRANCH, SENSE, MID, NBRVAR, BUILTIN, Nesting,
@@ -251,12 +252,12 @@ class TestSemanticsByRound extends AnyFunSpec with Matchers:
     // ARRANGE
     val ctx1 = ctx(0, Map(1 -> Export(FoldHood(0) -> 7), 2 -> Export(FoldHood(0) -> 7)))
 
-    def program1 = foldhood("init")(_ + _)(rep(0)(_ + 1) + "")
+    def program1 = foldhood("init")(_ + _)(rep(0)(_ + 1).toString)
 
     val ctx2 =
       ctx(0, Map(1 -> Export(FoldHood(0) -> 7), 2 -> Export(FoldHood(0) -> 7, FoldHood(0) / Nbr(0) -> 7)))
 
-    def program2 = foldhood("init")(_ + _)(nbr(rep(0)(_ + 1)) + "")
+    def program2 = foldhood("init")(_ + _)(nbr(rep(0)(_ + 1)).toString)
 
     // ACT + ASSERT
     val exp1 = round(ctx1, program1)
@@ -290,10 +291,10 @@ class TestSemanticsByRound extends AnyFunSpec with Matchers:
     )
 
     // ACT + ASSERT
-    round(ctx1, foldhood("init")(_ + _)(foldhood(0)(_ + _)(1) + "")).root[String]() shouldEqual "init333"
+    round(ctx1, foldhood("init")(_ + _)(foldhood(0)(_ + _)(1).toString)).root[String]() shouldEqual "init333"
 
     assertPossibleFolds("init", List("init", "7", "2")) {
-      round(ctx1, foldhood("init")(_ + _)(nbr(foldhood(0)(_ + _)(1)) + "")).root[String]()
+      round(ctx1, foldhood("init")(_ + _)(nbr(foldhood(0)(_ + _)(1)).toString)).root[String]()
     }
   }
 

--- a/src/test/scala/io/github/rustfields/functional/TestSemanticsByRound.scala
+++ b/src/test/scala/io/github/rustfields/functional/TestSemanticsByRound.scala
@@ -193,7 +193,7 @@ class TestSemanticsByRound extends AnyFunSpec with Matchers:
     // ACT + ASSERT (failure as no sensor 'c' is found)
     intercept[SensorUnknownException](round(ctx1, sense[Any]("c")))
     // ACT + ASSERT (failure if an existing sensor does not provide desired kind of data)
-    intercept[AnyRef](round(ctx1, sense[Boolean]("a")))
+    intercept[AnyRef](round(ctx1, (sense[Boolean]("a")): Boolean))
   }
 
   MID("should simply evaluate to the ID of the local device") {

--- a/src/test/scala/io/github/rustfields/functional/TestSemanticsByRound.scala
+++ b/src/test/scala/io/github/rustfields/functional/TestSemanticsByRound.scala
@@ -1,5 +1,329 @@
 package io.github.rustfields.functional
 
-class TestSemanticsByRound {
+import io.github.rustfields.functional.CoreTestUtils.ctx
+import io.github.rustfields.lang.FieldCalculusInterpreter
+import io.github.rustfields.vm.Export
+import io.github.rustfields.vm.Slot.*
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.matchers.should.Matchers.shouldBe
+import io.github.rustfields.vm.Path.*
 
-}
+class TestSemanticsByRound extends AnyFunSpec with Matchers:
+  val LocalValues, Alignment, Exports, FOLDHOOD, NBR, REP, BRANCH, SENSE, MID, NBRVAR, BUILTIN, Nesting,
+  DeferredExports = new ItWord
+  given FieldCalculusInterpreter = CoreTestInterpreter
+  import CoreTestInterpreter.*
+
+  LocalValues("should simply evaluate to themselves") {
+    // ARRANGE
+    val context = ctx(selfId = 0, exports = Map())
+    // ACT
+    val res = round(context, 77).root[Int]()
+    // ASSERT
+    res shouldBe 77
+  }
+
+  Alignment("should support interaction only between structurally compatible devices") {
+    // ARRANGE
+    val ctx1 = ctx(selfId = 0)
+    // ACT + ASSERT (no neighbor is aligned)
+    round(ctx1, rep(0)(foldhood(_)(_ + _)(1))).root[Int]() shouldBe 1
+    // ARRANGE
+    val exp = Map(1 -> Export(Rep(0) -> 1, Rep(0) / FoldHood(0) -> 1))
+    val ctx2 = ctx(selfId = 0, exports = exp)
+    // ACT + ASSERT (one neighbor is aligned)
+    round(ctx2, rep(0)(foldhood(_)(_ + _)(1))).root[Int]() shouldBe 2
+  }
+
+  Exports("should compose") {
+    val ctx1 = ctx(selfId = 0, Map(), Map("sensor" -> 5))
+    def expr1 = 1
+    def expr2 = rep(7)(_ + 1)
+    def expr3 = foldhood(0)(_ + _)(nbr(sense[Int]("sensor")))
+    /* Given expr 'e' produces exports 'o'
+     * What exports are produced by 'e + e + e + e' ?
+     */
+    round(ctx1, expr1 + expr1 + expr1 + expr1) shouldEqual
+      Export(/ -> 4)
+    round(ctx1, expr2 + expr2 + expr2 + expr2) shouldEqual
+      Export(/ -> 32, Rep(0) -> 8, Rep(1) -> 8, Rep(2) -> 8, Rep(3) -> 8)
+    round(ctx1, expr3 + expr3 + expr3 + expr3) shouldEqual
+      Export(
+        / -> 20,
+        FoldHood(0) / Nbr(0) -> 5,
+        FoldHood(1) / Nbr(0) -> 5,
+        FoldHood(2) / Nbr(0) -> 5,
+        FoldHood(3) / Nbr(0) -> 5,
+        FoldHood(0) -> 5,
+        FoldHood(1) -> 5,
+        FoldHood(2) -> 5,
+        FoldHood(3) -> 5
+      )
+
+    // Note: with the current implementation, the following, commented tested expression
+    //  is not aligned with the previous one.
+    //  Current impl of foldHood increments the index even though Nbr is not
+    //  used inside. It shouldn't be an issue as foldHood is to be used with Nbr.
+    // def expr4 = foldhood(0)(_+_)(nbr(sense[Int]("sensor")))
+    // round(ctx1, expr4 + expr4 + foldhood(0)(_+_)(1) + expr4 + expr4) shouldEqual
+    //  Export(emptyPath() -> 21, path(Nbr(0)) -> 5, path(Nbr(1)) -> 5, path(Nbr(2)) -> 5,
+    //    path(Nbr(3)) -> 5)
+
+    /* Given expr 'e' produces exports 'o'
+     * What exports are produced by 'rep(0){ rep(o){ e } }' ?
+     */
+    round(ctx1, rep(0)(_ => rep(0)(_ => expr1))) shouldEqual
+      Export(/ -> 1, Rep(0) -> 1, Rep(0) / Rep(0) -> 1)
+    round(ctx1, rep(0)(_ => rep(0)(_ => expr2))) shouldEqual
+      Export(/ -> 8, Rep(0) -> 8, Rep(0) / Rep(0) -> 8, Rep(0) / Rep(0) / Rep(0) -> 8)
+    round(ctx1, rep(0)(_ => rep(0)(_ => expr3))) shouldEqual
+      Export(
+        / -> 5,
+        Rep(0) -> 5,
+        Rep(0) / Rep(0) -> 5,
+        Rep(0) / Rep(0) / FoldHood(0) -> 5,
+        Rep(0) / Rep(0) / FoldHood(0) / Nbr(0) -> 5
+      )
+
+    /* Testing more NBRs within foldhood
+     */
+    round(ctx1, foldhood(0)(_ + _)(nbr(sense[Int]("sensor")) + nbr(sense[Int]("sensor")))) shouldEqual
+      Export(/ -> 10, FoldHood(0) -> 10, FoldHood(0) / Nbr(0) -> 5, FoldHood(0) / Nbr(1) -> 5)
+  }
+
+  FOLDHOOD("should support aggregating information from aligned neighbors") {
+    // ARRANGE
+    val exp1 = Map(2 -> Export(/ -> "a", FoldHood(0) -> "a"), 4 -> Export(/ -> "b", FoldHood(0) -> "b"))
+    val ctx1 = ctx(selfId = 0, exports = exp1)
+    // ACT + ASSERT
+    round(ctx1, foldhood("a")(_ + _)("z")).root[String]() shouldBe "azzz"
+
+    // ARRANGE
+    val exp2 = Map(2 -> Export(/ -> "a", FoldHood(0) -> "a"), 4 -> Export(/ -> "b", FoldHood(0) -> "b"))
+    val ctx2 = ctx(selfId = 0, exports = exp2)
+    // ACT + ASSERT (should failback to 'init' when neighbors lose alignment within foldhood)
+    round(
+      ctx2,
+      foldhood(-5)(_ + _)(if (nbr(false)) {
+        0
+      }
+      else {
+        1
+      })
+    ).root[Int]() shouldBe -14
+  }
+
+  NBR("needs not to be nested into fold") {
+    // ARRANGE
+    val ctx1 = ctx(selfId = 0)
+    // ACT + ASSERT
+    round(ctx1, nbr(1)).root[Int]() shouldBe 1
+  }
+
+  NBR("should support interaction between aligned devices") {
+    // ARRANGE
+    val exp1 = Map(
+      1 -> Export(/ -> "any", FoldHood(0) -> 1, FoldHood(0) / Nbr(0) -> 1),
+      2 -> Export(/ -> "any", FoldHood(0) -> 2, FoldHood(0) / Nbr(0) -> 2)
+    )
+    val ctx1 = ctx(selfId = 0, exports = exp1)
+    // ACT
+    val res1 = round(ctx1, foldhood(0)(_ + _)(if (nbr(mid()) == mid()) 0 else 1))
+    // ASSERT
+    res1.root[Int]() shouldBe 2
+    res1.get(FoldHood(0) / Nbr(0)) shouldBe Some(0)
+  }
+
+  REP("should support dynamic evolution of fields") {
+    // ARRANGE
+    val ctx1 = ctx(selfId = 0)
+    // ACT
+    val exp1 = round(ctx1, rep(9)(_ * 2))
+    // ASSERT (use initial value)
+    exp1.root[Int]() shouldBe 18
+    exp1.get(/(Rep(0))) shouldBe Some(18)
+
+    // ARRANGE
+    val exp = Map(0 -> Export(Rep(0) -> 7))
+    val ctx2 = ctx(selfId = 0, exports = exp)
+    // ACT
+    val exp2 = round(ctx2, rep(9)(_ * 2))
+    // ASSERT (build upon previous state)
+    exp2.root[Int]() shouldBe 14
+    exp2.get(/(Rep(0))) shouldBe Some(14)
+  }
+
+  BRANCH("should support domain restriction, thus affecting the structure of exports") {
+    // ARRANGE
+    def program =
+      rep(0) { x => branch(x % 2 == 0)(7)(rep(4)(_ => 4)); x + 1 }
+
+    // ACT
+    val exp = round(ctx(0), program)
+    // ASSERT
+    exp.root[Int]() shouldBe 1
+    //exp.get(path(If(0, true), Rep(0))) shouldBe Some(7)
+    //exp.get(path(If(0, false), Rep(0))) shouldBe None
+
+    // ACT
+    val ctx2 = ctx(0, Map(0 -> Export(Rep(0) -> 1)))
+    val exp2 = round(ctx2, program)
+
+    exp2.root[Int]() shouldBe 2
+    //exp2.get(path(If(0, true), Rep(0))) shouldBe None
+    //exp2.get(path(If(0, false), Rep(0))) shouldBe Some(4)
+    //exp2.get(path(Rep(0), If(0, false), Rep(0))) shouldBe Some(4)
+  }
+
+  SENSE("should simply evaluate to the last value read by sensor") {
+    // ARRANGE
+    val ctx1 = ctx(0, Map(), Map("a" -> 7, "b" -> "high"))
+    // ACT + ASSERT (failure as no sensor 'c' is found)
+    round(ctx1, sense[Any]("a")).root[Int]() shouldBe 7
+    round(ctx1, sense[Any]("b")).root[String]() shouldBe "high"
+  }
+
+  SENSE("should fail if the sensor is not available") {
+    // ARRANGE
+    val ctx1 = ctx(0, Map(), Map("a" -> 1, "b" -> 2))
+    // ACT + ASSERT (failure as no sensor 'c' is found)
+    intercept[AnyRef](round(ctx1, sense[Any]("c")))
+    // ACT + ASSERT (failure if an existing sensor does not provide desired kind of data)
+    intercept[AnyRef](round(ctx1, sense[Boolean]("a")))
+  }
+
+  MID("should simply evaluate to the ID of the local device") {
+    // ACT + ASSERT
+    round(ctx(77), mid()).root[Int]() shouldBe 77
+    round(ctx(8), mid()).root[Int]() shouldBe 8
+  }
+
+  NBRVAR("should work as a ''sensor'' for neighbors") {
+    // ARRANGE
+    val nbsens: Map[String, Map[Int, Any]] = Map("a" -> Map(0 -> 0, 1 -> 10, 2 -> 17), "b" -> Map(0 -> "x", 1 -> "y", 2 -> "z"))
+    val ctx1 = ctx(0, Map(1 -> Export(/ -> 10, FoldHood(0) -> 10)), Map(), nbsens)
+    // ACT + ASSERT
+    round(ctx1, foldhood(0)((a, b) => if (a > b) a else b)(nbrVar[Int]("a"))).root[Int]() shouldBe 10
+
+    // ACT + ASSERT (should fail when used outside fooldhood)
+    intercept[Exception](round(ctx1, nbrVar[Int]("a")))
+  }
+
+  NBRVAR("should fail if the neighborhood ''sensor'' is not available") {
+    // ARRANGE
+    val nbsens = Map("a" -> Map(0 -> 0, 1 -> 10, 2 -> 17))
+    val ctx1 = ctx(0, Map(1 -> Export(/ -> 10)), Map(), nbsens)
+    // ACT + ASSERT (failure because of bad type)
+    intercept[AnyRef](round(ctx1, foldhood("")(_ + _)(nbrVar[String]("a"))))
+    // ACT + ASSERT (failure because not found)
+    intercept[AnyRef](round(ctx1, foldhood(0)(_ + _)(nbrVar[Int]("xxx"))))
+  }
+
+  BUILTIN("minHood and minHood+, maxHood and maxHood+") {
+    // ARRANGE
+    val exp1 = Map(
+      1 -> Export(/ -> "any", FoldHood(0) -> 10, FoldHood(0) / Nbr(0) -> 10),
+      2 -> Export(/ -> "any", FoldHood(0) -> 5, FoldHood(0) / Nbr(0) -> 5)
+    )
+    val ctx1 = ctx(0, exp1, Map("sensor" -> 3, "sensor2" -> 20))
+    // ACT + ASSERT
+    round(ctx1, minHood(nbr(sense[Int]("sensor")))).root[Int]() shouldBe 3
+    round(ctx1, maxHood(nbr(sense[Int]("sensor2")))).root[Int]() shouldBe 20
+
+    /** N.B. foldHoodPlus, minHoodPlus, maxHoodPlus should be considered as
+     * *  "library" methods (not primitives), thus it may be better to not
+     * *  test exports for them. For now, however, we keep these tests.
+     * */
+    // ARRANGE
+    val exp2 = Map(
+      1 -> Export(/ -> "any", FoldHood(0) -> 1, FoldHood(0) / Nbr(0) -> 1, FoldHood(0) / Nbr(1) -> 10),
+      2 -> Export(/ -> "any", FoldHood(0) -> 2, FoldHood(0) / Nbr(0) -> 2, FoldHood(0) / Nbr(1) -> 5)
+    )
+    // Note: the export on Nbr(0) is for the internal call to nbr(mid())
+    val ctx2 = ctx(0, exp2, Map("sensor" -> 3, "sensor2" -> 20))
+    // ACT + ASSERT
+    round(ctx2, minHoodPlus(nbr(sense[Int]("sensor")))).root[Int]() shouldBe 5
+    round(ctx2, maxHoodPlus(nbr(sense[Int]("sensor2")))).root[Int]() shouldBe 10
+  }
+
+  Nesting("REP into FOLDHOOD should be supported") {
+    // ARRANGE
+    var ctx1 = ctx(0, Map(1 -> Export(FoldHood(0) -> 7), 2 -> Export(FoldHood(0) -> 7)))
+
+    def program1 = foldhood("init")(_ + _)(rep(0)(_ + 1) + "")
+
+    var ctx2 =
+      ctx(0, Map(1 -> Export(FoldHood(0) -> 7), 2 -> Export(FoldHood(0) -> 7, FoldHood(0) / Nbr(0) -> 7)))
+
+    def program2 = foldhood("init")(_ + _)(nbr(rep(0)(_ + 1)) + "")
+
+    // ACT + ASSERT
+    val exp1 = round(ctx1, program1)
+    exp1.root[String]() shouldEqual "init111"
+    ctx1 = ctx1.putExport(0, exp1)
+    round(ctx1, program1).root[String]() shouldEqual "init222"
+
+    val exp2 = round(ctx2, program2)
+    assertPossibleFolds("init", List("init", "7", "1")) {
+      exp2.root[String]()
+    }
+    ctx2 = ctx2.putExport(0, exp2)
+    assertPossibleFolds("init", List("init", "7", "2")) {
+      round(ctx2, program2).root[String]()
+    }
+  }
+
+  Nesting("FOLDHOOD into FOLDHOOD should be supported") {
+    // ARRANGE
+    val ctx1 = ctx(
+      0,
+      Map(
+        1 -> Export(FoldHood(0) -> 7, FoldHood(0) / FoldHood(0) -> 7),
+        2 -> Export(
+          FoldHood(0) -> 7,
+          FoldHood(0) / Nbr(0) -> 7,
+          FoldHood(0) / FoldHood(0) -> 7,
+          FoldHood(0) / Nbr(0) / FoldHood(0) -> 7
+        )
+      )
+    )
+
+    // ACT + ASSERT
+    round(ctx1, foldhood("init")(_ + _)(foldhood(0)(_ + _)(1) + "")).root[String]() shouldEqual "init333"
+
+    assertPossibleFolds("init", List("init", "7", "2")) {
+      round(ctx1, foldhood("init")(_ + _)(nbr(foldhood(0)(_ + _)(1)) + "")).root[String]()
+    }
+  }
+
+  DeferredExports("should work in a recurrent fashion") {
+    val exp = round(
+      ctx(0), {
+        vm.newExportStack
+        rep(0) { _ =>
+          vm.newExportStack
+          rep(0) { _ =>
+            vm.newExportStack
+            rep(0)(_ + 1)
+            vm.mergeExport
+            1
+          }
+          foldhood(0)(_ + _)(nbr(1))
+          vm.discardExport
+          1
+        }
+        foldhood(0)(_ + _)(nbr(1))
+        vm.mergeExport
+      }
+    )
+
+    exp.get(/ / Rep(0)) should be(defined)
+    exp.get(/ / FoldHood(1)) should be(defined)
+    exp.get(/ / Rep(0) / Rep(0)) should not be defined
+    exp.get(/ / Rep(0) / FoldHood(1)) should not be defined
+    exp.get(/ / Rep(0) / Rep(0) / Rep(0)) should not be defined
+  }
+
+  private def assertPossibleFolds(init: Any, a: List[Any])(expr: => Any): Unit =
+    a.permutations.map(l => s"$init${l.mkString}").toList should contain(expr)

--- a/src/test/scala/io/github/rustfields/functional/TestSemanticsByRound.scala
+++ b/src/test/scala/io/github/rustfields/functional/TestSemanticsByRound.scala
@@ -249,11 +249,11 @@ class TestSemanticsByRound extends AnyFunSpec with Matchers:
 
   Nesting("REP into FOLDHOOD should be supported") {
     // ARRANGE
-    var ctx1 = ctx(0, Map(1 -> Export(FoldHood(0) -> 7), 2 -> Export(FoldHood(0) -> 7)))
+    val ctx1 = ctx(0, Map(1 -> Export(FoldHood(0) -> 7), 2 -> Export(FoldHood(0) -> 7)))
 
     def program1 = foldhood("init")(_ + _)(rep(0)(_ + 1) + "")
 
-    var ctx2 =
+    val ctx2 =
       ctx(0, Map(1 -> Export(FoldHood(0) -> 7), 2 -> Export(FoldHood(0) -> 7, FoldHood(0) / Nbr(0) -> 7)))
 
     def program2 = foldhood("init")(_ + _)(nbr(rep(0)(_ + 1)) + "")
@@ -261,16 +261,16 @@ class TestSemanticsByRound extends AnyFunSpec with Matchers:
     // ACT + ASSERT
     val exp1 = round(ctx1, program1)
     exp1.root[String]() shouldEqual "init111"
-    ctx1 = ctx1.putExport(0, exp1)
-    round(ctx1, program1).root[String]() shouldEqual "init222"
+    val ctx1b = ctx1.putExport(0, exp1)
+    round(ctx1b, program1).root[String]() shouldEqual "init222"
 
     val exp2 = round(ctx2, program2)
     assertPossibleFolds("init", List("init", "7", "1")) {
       exp2.root[String]()
     }
-    ctx2 = ctx2.putExport(0, exp2)
+    val ctx2b = ctx2.putExport(0, exp2)
     assertPossibleFolds("init", List("init", "7", "2")) {
-      round(ctx2, program2).root[String]()
+      round(ctx2b, program2).root[String]()
     }
   }
 

--- a/src/test/scala/io/github/rustfields/functional/TestSemanticsByRound.scala
+++ b/src/test/scala/io/github/rustfields/functional/TestSemanticsByRound.scala
@@ -8,6 +8,8 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.matchers.should.Matchers.shouldBe
 import io.github.rustfields.vm.Path.*
+import io.github.rustfields.vm.RoundVM.SensorUnknownException
+
 import scala.language.implicitConversions
 
 class TestSemanticsByRound extends AnyFunSpec with Matchers:
@@ -189,7 +191,7 @@ class TestSemanticsByRound extends AnyFunSpec with Matchers:
     // ARRANGE
     val ctx1 = ctx(0, Map(), Map("a" -> 1, "b" -> 2))
     // ACT + ASSERT (failure as no sensor 'c' is found)
-    intercept[AnyRef](round(ctx1, sense[Any]("c")))
+    intercept[SensorUnknownException](round(ctx1, sense[Any]("c")))
     // ACT + ASSERT (failure if an existing sensor does not provide desired kind of data)
     intercept[AnyRef](round(ctx1, sense[Boolean]("a")))
   }

--- a/src/test/scala/io/github/rustfields/functional/TestSemanticsByRound.scala
+++ b/src/test/scala/io/github/rustfields/functional/TestSemanticsByRound.scala
@@ -1,0 +1,5 @@
+package io.github.rustfields.functional
+
+class TestSemanticsByRound {
+
+}


### PR DESCRIPTION
- test: add TestSemanticsByRound and TestByEquivalence classes
- test: add CoreTestInterpreter
- test: add CoreTestUtils
- test: add TestByEquivalence/
- test: change test name
- test: add TestSemanticsByRound implementation
- test: define Random seeds to use always the same sequence
- test: swith from var to val in test
- chore: add scalac options for deprecation and feature
- test: fix feature and deprecation warnings
- build: add fork=true in SBT
- test: fix part of should fail if the sensor is not available
- test: fix should fail if the sensor is not available
