### PR TITLE
refactor: remove vm factory

### DIFF
--- a/src/main/scala/io/github/rustfields/lang/FieldCalculusExecution.scala
+++ b/src/main/scala/io/github/rustfields/lang/FieldCalculusExecution.scala
@@ -1,7 +1,6 @@
 package io.github.rustfields.lang
 
 import io.github.rustfields.vm.{Context, Export, RoundVM}
-import io.github.rustfields.vm.{StandardVMFactory, VMFactory}
 
 trait FieldCalculusExecution extends (Context => Export) with LangImpl:
 

--- a/src/main/scala/io/github/rustfields/lang/FieldCalculusExecution.scala
+++ b/src/main/scala/io/github/rustfields/lang/FieldCalculusExecution.scala
@@ -4,7 +4,6 @@ import io.github.rustfields.vm.{Context, Export, RoundVM}
 import io.github.rustfields.vm.{StandardVMFactory, VMFactory}
 
 trait FieldCalculusExecution extends (Context => Export) with LangImpl:
-  self: VMFactory =>
 
   type MainResult
 
@@ -16,16 +15,13 @@ trait FieldCalculusExecution extends (Context => Export) with LangImpl:
     round(c, main())
 
   final def round(c: Context, e: => Any = main()): Export =
-    vm = createVM(c)
+    vm = RoundVM(c)
     val result = e
     vm.registerRoot(result)
     vm.exportData
 
-trait FieldCalculusInterpreter extends FieldCalculusExecution with FieldCalculusSyntax with StandardVMFactory:
+trait FieldCalculusInterpreter extends FieldCalculusExecution with FieldCalculusSyntax:
   type MainResult = Any
   final def main(): Any = ()
 
-trait BaseProgram extends FieldCalculusExecution with FieldCalculusSyntax:
-    factory: VMFactory =>
-
-trait AggregateProgram extends BaseProgram with StandardVMFactory
+trait AggregateProgram extends FieldCalculusExecution with FieldCalculusSyntax

--- a/src/main/scala/io/github/rustfields/vm/RoundVM.scala
+++ b/src/main/scala/io/github/rustfields/vm/RoundVM.scala
@@ -232,9 +232,3 @@ object RoundVM:
       val toMerge = exportData
       exports = exports.tail
       toMerge.paths.foreach(tp => exportData.put(tp._1, tp._2))
-
-trait VMFactory:
-  def createVM(c: Context): RoundVM
-
-trait StandardVMFactory extends VMFactory:
-  override def createVM(c: Context): RoundVM = RoundVM(c)


### PR DESCRIPTION
I removed the VM Factory since we do not foresee the creation of alternative VM's (such as the NativeVM) anymore